### PR TITLE
[FIX] base: update XML ids of automatic fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -818,7 +818,7 @@ class IrModelFields(models.Model):
                 keys = [key for key in new_vals if old_vals[key] != new_vals[key]]
                 self.pool.post_init(record.modified, keys)
                 old_vals.update(new_vals)
-            if module and (old_vals is None or module in field._modules):
+            if module and (module == model._module or module in field._modules):
                 to_xmlids.append(name)
 
         if to_insert:


### PR DESCRIPTION
Upon module upgrade, automatic fields are removed from `ir.model.fields`.  This
is because those fields do not belong to the module of their model.  Fix the
condition to update their XML id when the module of their model is upgraded.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
