### PR TITLE
[FIX] auth_password_policy: remove deferred when not needed

### DIFF
--- a/addons/auth_password_policy/static/src/js/password_field.js
+++ b/addons/auth_password_policy/static/src/js/password_field.js
@@ -21,12 +21,12 @@ var PasswordField = fields.InputField.extend({
     },
     willStart: function () {
         var _this = this;
-        var getPolicy = this._rpc({
+        var getPolicy = this.nodeOptions['password_meter'] ? this._rpc({
             model: 'res.users',
             method: 'get_password_policy',
         }).then(function (p) {
             _this._meter = new Meter(_this, new policy.Policy(p), policy.recommendations);
-        });
+        }) : undefined;
         return $.when(
             this._super.apply(this, arguments),
             getPolicy


### PR DESCRIPTION
When auth_password_policy is installed, and a field with
`password="True"` is in a res.config.settings (eg. google calendar is
installed) we could have an error caused by deferred not expected in the
res.config.settings _render.

Since the RPC is only needed when the password_policy has been been
defined, this commit do this removing the error that currently happened.

A customization of res.config.settings adding password_meter would still
break settings (but it is currently not done) and will be solved in a
future fix.
closes #27426

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
