### PR TITLE
[FIX] (website_)sale: hide single attribute value in p. configurator

### DIFF
--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -75,7 +75,7 @@ class ProductAttributeValue(models.Model):
         attribute type is 'Color'.""")
 
 
-class ProductProductAttributeValue(models.Model):
+class ProductTemplateAttributeValue(models.Model):
     _inherit = "product.template.attribute.value"
 
     html_color = fields.Char('HTML Color Index', related="product_attribute_value_id.html_color")

--- a/addons/sale/views/sale_product_configurator_templates.xml
+++ b/addons/sale/views/sale_product_configurator_templates.xml
@@ -177,7 +177,10 @@
       <t t-set="attribute_exclusions" t-value="get_attribute_exclusions(product, reference_product)"/>
       <ul t-attf-class="list-unstyled js_add_cart_variants #{ul_class}" t-att-data-attribute_exclusions="json.dumps(attribute_exclusions)">
         <t t-foreach="product.attribute_line_ids.sorted(key=lambda x: x.attribute_id.sequence)" t-as="variant_id">
-          <li t-att-data-attribute_id="variant_id.attribute_id.id" t-att-data-attribute_name="variant_id.attribute_id.name" class="variant_attribute">
+          <!-- Attributes selection is hidden if there is only one value available and it's not a custom value -->
+          <li t-att-data-attribute_id="variant_id.attribute_id.id"
+                t-att-data-attribute_name="variant_id.attribute_id.name"
+                t-attf-class="variant_attribute #{'d-none' if len(variant_id.product_template_value_ids) == 1 and not variant_id.product_template_value_ids[0].is_custom else ''}">
 
             <strong t-field="variant_id.attribute_id.name" class="attribute_name" />
 


### PR DESCRIPTION
Targets commit d3530eb07e24278117ab396ecb86a59deecc312d
References task id 1892022

Purpose
=======
- When there is only one attribute value for an attribute configured in a product's variants,
  it should be hidden in the product configurator.
  e.g: The only value selected for the "Material" attribute is the "Wood" value for the "Customizable Desk".
  The radio selection is hidden and "Material: Wood" is displayed in the product's description.

- Fixed a class name typo

closes odoo/odoo#27604

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
