### PR TITLE
[FIX] web: no duplication function for `change_menu_section`

### DIFF
--- a/addons/web/static/src/js/chrome/menu.js
+++ b/addons/web/static/src/js/chrome/menu.js
@@ -38,7 +38,7 @@ var Menu = Widget.extend({
         });
 
         // Bus event
-        core.bus.on('change_menu_section', this, this._onChangeMenuSection);
+        core.bus.on('change_menu_section', this, this.change_menu_section);
     },
     start: function () {
         var self = this;
@@ -195,36 +195,6 @@ var Menu = Widget.extend({
     _onAppNameClicked: function (ev) {
         var actionID = parseInt(this.menu_id_to_action_id(this.current_primary_menu));
         this._trigger_menu_clicked(this.current_primary_menu, actionID);
-    },
-    /**
-     * @private
-     * @param {integer} primaryMenuID
-     */
-    _onChangeMenuSection: function (primaryMenuID) {
-        if (!this.$menu_sections[primaryMenuID]) {
-            return; // unknown menu_id
-        }
-
-        if (this.current_primary_menu === primaryMenuID) {
-            return; // already in that menu
-        }
-
-        if (this.current_primary_menu) {
-            this.$menu_sections[this.current_primary_menu].detach();
-        }
-
-        // Get back the application name
-        for (var i = 0; i < this.menu_data.children.length; i++) {
-            if (this.menu_data.children[i].id === primaryMenuID) {
-                this.$menu_brand_placeholder.text(this.menu_data.children[i].name);
-                break;
-            }
-        }
-
-        this.$menu_sections[primaryMenuID].appendTo(this.$section_placeholder);
-        this.current_primary_menu = primaryMenuID;
-
-        core.bus.trigger('resize');
     },
     /**
      * @private


### PR DESCRIPTION
Revision on https://github.com/odoo/odoo/commit/b7cf456560dc4fd7c1217ba90f0b5609466ede50

The commit above assumed the function `change_menu_section` was
mistakenly removed. However, it was turned into a handler function
and renamed according to our JS guidelines `_onChangeMenuSection`.

This commit removes the duplicated logic by removing the
function `_onChangeMenuSection` and using `change_menu_section`
as the handler for the bus event `change_menu_section`.

closes odoo/odoo#27809

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
