### PR TITLE
[FIX] models: restore warning on wrong record

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3791,6 +3791,14 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                 else:
                     imd.browse(d_id).unlink()
 
+        # check for records to create with an XMLID from another module
+        module = self.env.context.get('install_module')
+        if module:
+            prefix = module + "."
+            for data in to_create:
+                if data.get('xml_id') and not data['xml_id'].startswith(prefix):
+                    _logger.warning("Creating record %s in module %s.", data['xml_id'], module)
+
         # create records
         records = self.create([data['values'] for data in to_create])
         for data, record in pycompat.izip(to_create, records):

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -832,6 +832,8 @@ def convert_csv_import(cr, module, fname, csvcontent, idref=None, mode='init',
     context = {
         'mode': mode,
         'module': module,
+        'install_module': module,
+        'install_filename': fname,
         'noupdate': noupdate,
     }
     env = odoo.api.Environment(cr, SUPERUSER_ID, context)


### PR DESCRIPTION
Was lost during d5b687a48ffb

Set the module name in the context to be able to detect errors in xml and csv import

closes odoo/odoo#27680

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
