### PR TITLE
[FIX] sale: Wrong expected delivery time for orders with services

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -49,7 +49,7 @@ class SaleOrder(models.Model):
         for order in self:
             dates_list = []
             confirm_date = fields.Datetime.from_string(order.confirmation_date if order.state == 'sale' else fields.Datetime.now())
-            for line in order.order_line.filtered(lambda x: x.state != 'cancel'):
+            for line in order.order_line.filtered(lambda x: x.state != 'cancel' and not x._is_delivery()):
                 dt = confirm_date + timedelta(days=line.customer_lead or 0.0)
                 dates_list.append(dt)
             if dates_list:


### PR DESCRIPTION
When doing a sale order containing product and services, the
computed minimal expected delivery time was using the customer lead
time of the services (which is always 0) instead of the minimum
customer lead time of the products.

To reproduce:
1) Install Sales and Delivery Cost.
2) Go to the sales settings and enable the "Delivery Date" option.
3) Set a customer lead time on a product.
4) Create a quotation with that product, any service and a
   delivery method.
5) Validate the quotation and the delivery.
6) The "Expected Time" written in the "Other Information" tab of
   the sale order doesn't match the minimum delivery expected time.

opw-1902858

closes odoo/odoo#28208

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
