### PR TITLE
[FIX] bus: never GC during requests

### DIFF
--- a/addons/bus/models/__init__.py
+++ b/addons/bus/models/__init__.py
@@ -3,3 +3,4 @@ from . import bus
 from . import bus_presence
 from . import res_users
 from . import res_partner
+from . import ir_autovacuum

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -53,8 +53,6 @@ class ImBus(models.Model):
                 "message": json_dump(message)
             }
             self.sudo().create(values)
-            if random.random() < 0.01:
-                self.gc()
         if channels:
             # We have to wait until the notifications are commited in database.
             # When calling `NOTIFY imbus`, some concurrent threads will be

--- a/addons/bus/models/ir_autovacuum.py
+++ b/addons/bus/models/ir_autovacuum.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, models
+
+class AutoVacuum(models.AbstractModel):
+    _inherit = 'ir.autovacuum'
+
+    @api.model
+    def power_on(self, *args, **kwargs):
+        self.env['bus.bus'].gc()
+        return super(AutoVacuum, self).power_on(*args, **kwargs)


### PR DESCRIPTION
Running the bus garbage collector synchronously during the handling of a
request can stall the request for a very long time.

Instead, we add this step to the existing auto-vacuum scheduled job that
handles this kind of housecleaning. It brings another interesting bonus:
it can be scheduled outside of peak hours, which will avoid blocking other
bus-related transactions (the GC deletes a lot of rows and takes a lot
of exclusive locks in the database)

closes odoo/odoo#28326

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
