### PR TITLE
Revert "[IMP] account: Trigger a validation error when trying to set …

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -538,8 +538,6 @@ class AccountJournal(models.Model):
     @api.constrains('currency_id', 'default_credit_account_id', 'default_debit_account_id')
     def _check_currency(self):
         if self.currency_id:
-            if self.currency_id == self.company_id.currency_id:
-                raise ValidationError(_("Currency field should only be set if the journal's currency is different from the company's. Leave the field blank to use company currency."))
             if self.default_credit_account_id and not self.default_credit_account_id.currency_id.id == self.currency_id.id:
                 raise ValidationError(_('The currency of the journal should be the same than the default credit account.'))
             if self.default_debit_account_id and not self.default_debit_account_id.currency_id.id == self.currency_id.id:


### PR DESCRIPTION
…the same currency on a journal as on its parent company."

This commit shouldn't have been forward-ported to this branch.

This reverts commit 22f0da809e84618901b7ca4b78582abd64c03c55.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
