### PR TITLE
[FIX] web: dateField datepicker don't propagate field options

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -501,6 +501,7 @@ var FieldDate = InputField.extend({
         // use the session timezone when formatting dates
         this.formatOptions.timezone = true;
         this.datepickerOptions = _.defaults(
+            {},
             this.nodeOptions.datepicker || {},
             {defaultDate: this.value}
         );

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -2776,6 +2776,42 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('date field with warn_future option: do not overwrite datepicker option', function (assert) {
+        assert.expect(2);
+
+        // Making sure we don't have a legit default value
+        // or any onchange that would set the value
+        this.data.partner.fields.date.default = undefined;
+        this.data.partner.onchanges = {};
+
+        var form = createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch:'<form string="Partners">' +
+                    '<field name="foo" />' + // Do not let the date field get the focus in the first place
+                    '<field name="date" options="{\'datepicker\': {\'warn_future\': true}}"/>' +
+                 '</form>',
+            res_id: 1,
+        });
+
+        // switch to edit mode
+        form.$buttons.find('.o_form_button_edit').click();
+        assert.strictEqual(form.$('input[name="date"]').val(), '02/03/2017',
+            'The existing record should have a value for the date field');
+
+        // save with no changes
+        form.$buttons.find('.o_form_button_save').click();
+
+        //Create a new record
+        form.$buttons.find('.o_form_button_create').click();
+
+        assert.notOk(form.$('input[name="date"]').val(),
+            'The new record should not have a value that the framework would have set');
+
+        form.destroy();
+    });
+
     QUnit.test('date field in editable list view', function (assert) {
         assert.expect(8);
 


### PR DESCRIPTION
In a form view (account.invoice), have a date field as:

    <field name="date" options="{\'datepicker\': {\'warn_future\': true}}"/>

Open a record with the field set to a value
Click Edit, click save
Click create

Before this commit, the value of the field of the new record
took the one of the previous record

On account invoices, it resulted on having the popup "The record has been modified etc...."
And it was not possible to create an invoice from another one

this was because we passed the same reference object for the datepicker

After this commit, there is no popup as the field do not take a value from the framework

OPW 1906085

closes odoo/odoo#28759

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
