### PR TITLE
[FIX] account_facturx: template should compute taxes with partner

### DIFF
--- a/addons/account_facturx/data/facturx_templates.xml
+++ b/addons/account_facturx/data/facturx_templates.xml
@@ -25,7 +25,7 @@
 
                     <!-- Amounts. -->
                     <ram:SpecifiedLineTradeAgreement>
-                        <t t-set="taxes" t-value="line.invoice_line_tax_ids.compute_all(line.price_unit)"/>
+                        <t t-set="taxes" t-value="line.invoice_line_tax_ids.compute_all(line.price_unit, partner=record.partner_id)"/>
                         <ram:GrossPriceProductTradePrice>
                             <ram:ChargeAmount
                                 t-att-currencyID="currency.name"


### PR DESCRIPTION
Otherwise account_tax_python will crash if 'partner' triggers a condition

OPW 1914928

closes odoo/odoo#29539

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
